### PR TITLE
flag GRIMMER `items` bug in docs

### DIFF
--- a/R/debit-map-seq.R
+++ b/R/debit-map-seq.R
@@ -45,8 +45,6 @@
 #'   next higher or lower consistent value, respectively.
 #'   - `diff_sd`, `diff_sd_up`, and `diff_sd_down` do the same for `sd`.
 #'   -  Likewise with `diff_n`, `diff_n_up`, and `diff_n_down`.
-#'
-#'   Call `audit()` following `audit_seq()` to summarize results even further.
 
 #' @return A tibble (data frame) with detailed test results.
 
@@ -70,13 +68,7 @@
 #' # can be more important than the raw results:
 #' out %>%
 #'   audit_seq()
-#'
-#' # Summarize across cases with `audit()`
-#' # following up on `audit_seq()`:
-#' out %>%
-#'   audit_seq() %>%
-#'   audit() %>%
-#'   suppressWarnings()
+
 
 debit_map_seq <- function_map_seq(
   .fun = debit_map,

--- a/R/debit-map-total-n.R
+++ b/R/debit-map-total-n.R
@@ -99,14 +99,6 @@
 #' df %>%
 #'   debit_map_total_n() %>%
 #'   audit_total_n()
-#'
-#' # Summarize across cases with `audit()`
-#' # following up on `audit_total_n()`:
-#' df %>%
-#'   debit_map_total_n() %>%
-#'   audit_total_n() %>%
-#'   audit()
-
 
 
 debit_map_total_n <- function_map_total_n(

--- a/R/grim-map-seq.R
+++ b/R/grim-map-seq.R
@@ -68,12 +68,6 @@
 #' # can be more important than the raw results:
 #' out %>%
 #'   audit_seq()
-#'
-#' # Summarize across cases with `audit()`
-#' # following up on `audit_seq()`:
-#' out %>%
-#'   audit_seq() %>%
-#'   audit()
 
 
 grim_map_seq <- function_map_seq(

--- a/R/grim-map-total-n.R
+++ b/R/grim-map-total-n.R
@@ -114,13 +114,6 @@
 #' df %>%
 #'   grim_map_total_n(dispersion = 0:10) %>%
 #'   audit_total_n()
-#'
-#' # Summarize across cases with `audit()`
-#' # following up on `audit_total_n()`:
-#' df %>%
-#'   grim_map_total_n() %>%
-#'   audit_total_n() %>%
-#'   audit()
 
 
 grim_map_total_n <- function_map_total_n(

--- a/R/grimmer-map-seq.R
+++ b/R/grimmer-map-seq.R
@@ -69,12 +69,6 @@
 #' # can be more important than the raw results:
 #' out %>%
 #'   audit_seq()
-#'
-#' # Summarize across cases with `audit()`
-#' # following up on `audit_seq()`:
-#' out %>%
-#'   audit_seq() %>%
-#'   audit()
 
 
 grimmer_map_seq <- function_map_seq(

--- a/R/grimmer-map-total-n.R
+++ b/R/grimmer-map-total-n.R
@@ -115,13 +115,6 @@
 #' df %>%
 #'   grimmer_map_total_n(dispersion = 0:10) %>%
 #'   audit_total_n()
-#'
-#' # Summarize across cases with `audit()`
-#' # following up on `audit_total_n()`:
-#' df %>%
-#'   grimmer_map_total_n() %>%
-#'   audit_total_n() %>%
-#'   audit()
 
 
 grimmer_map_total_n <- function_map_total_n(

--- a/man/debit_map_seq.Rd
+++ b/man/debit_map_seq.Rd
@@ -77,8 +77,6 @@ next higher or lower consistent value, respectively.
 \item \code{diff_sd}, \code{diff_sd_up}, and \code{diff_sd_down} do the same for \code{sd}.
 \item Likewise with \code{diff_n}, \code{diff_n_up}, and \code{diff_n_down}.
 }
-
-Call \code{audit()} following \code{audit_seq()} to summarize results even further.
 }
 
 \examples{
@@ -97,11 +95,4 @@ out
 # can be more important than the raw results:
 out \%>\%
   audit_seq()
-
-# Summarize across cases with `audit()`
-# following up on `audit_seq()`:
-out \%>\%
-  audit_seq() \%>\%
-  audit() \%>\%
-  suppressWarnings()
 }

--- a/man/debit_map_total_n.Rd
+++ b/man/debit_map_total_n.Rd
@@ -122,13 +122,6 @@ df \%>\%
 df \%>\%
   debit_map_total_n() \%>\%
   audit_total_n()
-
-# Summarize across cases with `audit()`
-# following up on `audit_total_n()`:
-df \%>\%
-  debit_map_total_n() \%>\%
-  audit_total_n() \%>\%
-  audit()
 }
 \references{
 Bauer, P. J., & Francis, G. (2021). Expression of Concern: Is It

--- a/man/grim_map_seq.Rd
+++ b/man/grim_map_seq.Rd
@@ -94,10 +94,4 @@ out
 # can be more important than the raw results:
 out \%>\%
   audit_seq()
-
-# Summarize across cases with `audit()`
-# following up on `audit_seq()`:
-out \%>\%
-  audit_seq() \%>\%
-  audit()
 }

--- a/man/grim_map_total_n.Rd
+++ b/man/grim_map_total_n.Rd
@@ -129,13 +129,6 @@ df \%>\%
 df \%>\%
   grim_map_total_n(dispersion = 0:10) \%>\%
   audit_total_n()
-
-# Summarize across cases with `audit()`
-# following up on `audit_total_n()`:
-df \%>\%
-  grim_map_total_n() \%>\%
-  audit_total_n() \%>\%
-  audit()
 }
 \references{
 Bauer, P. J., & Francis, G. (2021). Expression of Concern: Is It

--- a/man/grimmer_map_seq.Rd
+++ b/man/grimmer_map_seq.Rd
@@ -96,10 +96,4 @@ out
 # can be more important than the raw results:
 out \%>\%
   audit_seq()
-
-# Summarize across cases with `audit()`
-# following up on `audit_seq()`:
-out \%>\%
-  audit_seq() \%>\%
-  audit()
 }

--- a/man/grimmer_map_total_n.Rd
+++ b/man/grimmer_map_total_n.Rd
@@ -133,13 +133,6 @@ df \%>\%
 df \%>\%
   grimmer_map_total_n(dispersion = 0:10) \%>\%
   audit_total_n()
-
-# Summarize across cases with `audit()`
-# following up on `audit_total_n()`:
-df \%>\%
-  grimmer_map_total_n() \%>\%
-  audit_total_n() \%>\%
-  audit()
 }
 \references{
 Bauer, P. J., & Francis, G. (2021). Expression of Concern: Is It

--- a/vignettes/grimmer.Rmd
+++ b/vignettes/grimmer.Rmd
@@ -90,6 +90,8 @@ The `reason` column says why a set of values was inconsistent. To be GRIMMER-con
 
 ### Scale items
 
+**NOTE: Don't use the `items` argument. It currently contains a bug that will be fixed in scrutiny's next CRAN release.**
+
 If a mean is composed of multiple items, set the `items` parameter to that number. Below are hypothetical means of a three-items scale. With the single-item default, half of these are wrongly flagged as inconsistent:
 
 ```{r, error=TRUE}


### PR DESCRIPTION
This also reverts certain changes to the documentation I made in the meantime. These changes documented `audit()` methods for `audit_seq()` and `audit_total_n()`. They were meant for the next major or minor version, and will be reinstated that point.