### PR TITLE
Fixing risky vector comparisons

### DIFF
--- a/R/debit-table.R
+++ b/R/debit-table.R
@@ -131,13 +131,13 @@ debit_table <- function(x, sd, n,
   sd_upper_test    <- dustify(sd_upper)
 
   if (sd_incl_lower && sd_incl_upper) {
-    consistency <- any(sd_lower_test <= sd_rec_both_test) && any(sd_rec_both_test <= sd_upper_test)
+    consistency <- any(outer(sd_lower_test, sd_rec_both_test, "<=")) && any(outer(sd_rec_both_test, sd_upper_test, "<="))
   } else if (sd_incl_lower && !sd_incl_upper) {
-    consistency <- any(sd_lower_test <= sd_rec_both_test) && any(sd_rec_both_test  < sd_upper_test)
+        consistency <- any(outer(sd_lower_test, sd_rec_both_test, "<=")) && any(outer(sd_rec_both_test, sd_upper_test, "<"))
   } else if (!sd_incl_lower && sd_incl_upper) {
-    consistency <- any(sd_lower_test < sd_rec_both_test)  && any(sd_rec_both_test <= sd_upper_test)
+        consistency <- any(outer(sd_lower_test, sd_rec_both_test, "<")) && any(outer(sd_rec_both_test, sd_upper_test, "<="))
   } else {
-    consistency <- any(sd_lower_test < sd_rec_both_test)  && any(sd_rec_both_test  < sd_upper_test)
+        consistency <- any(outer(sd_lower_test, sd_rec_both_test, "<")) && any(outer(sd_rec_both_test, sd_upper_test, "<"))
   }
 
   # `n` is always a whole number, so it's good to convert it to integer:

--- a/R/grim.R
+++ b/R/grim.R
@@ -73,7 +73,7 @@ grim_scalar <- function(x, n, items = 1, percent = FALSE, show_rec = FALSE,
   } else {
     consistency <- grain_is_x
     length_2ers <- c("up_or_down", "up_from_or_down_from", "ceiling_or_floor")
-    if (any(length_2ers == rounding)) {
+    if (any(length_2ers %in% rounding)) {
       # Skipping those values that are identical to the selected ones apart from
       # `dust` addition or subtraction via `dustify()`:
       return(list(

--- a/R/unround.R
+++ b/R/unround.R
@@ -5,7 +5,7 @@ rounding_bounds_scalar <- function(rounding, x_num, d_var, d) {
 
   # Manage the two rounding procedures that depend on the sign of the input
   # number, rounding with truncation and "anti-truncation":
-  if (anyrounding %in% c("trunc", "anti_trunc")) {
+  if (any(rounding %in% c("trunc", "anti_trunc"))) {
     rounding_orig <- rounding
     if (x_num > 0) {
       rounding <- "trunc_x_greater"

--- a/R/unround.R
+++ b/R/unround.R
@@ -5,7 +5,7 @@ rounding_bounds_scalar <- function(rounding, x_num, d_var, d) {
 
   # Manage the two rounding procedures that depend on the sign of the input
   # number, rounding with truncation and "anti-truncation":
-  if (any(rounding == c("trunc", "anti_trunc"))) {
+  if (anyrounding %in% c("trunc", "anti_trunc")) {
     rounding_orig <- rounding
     if (x_num > 0) {
       rounding <- "trunc_x_greater"

--- a/R/utils.R
+++ b/R/utils.R
@@ -503,7 +503,7 @@ check_tibble <- function(x) {
 #'
 #' @noRd
 check_rounding_singular <- function(rounding, bad, good1, good2) {
-  if (any(bad == rounding)) {
+  if (any(bad %in% rounding)) {
     cli::cli_abort(c(
       "!" = "If `rounding` has length > 1, only single rounding procedures \\
       are supported, such as \"{good1}\" and \"{good2}\".",


### PR DESCRIPTION
Several places in the code put vector comparisons in the critical path, including the final consistency determination for debit_table. 

**Consequence 1:** DEBIT can unpredictably return False instead of True based on the ordering of elements. 
Specific test case: `debit("0.11", "0.31", 40, rounding = "anti_trunc”)`
Snapshot: 
```
sd_rec_test_both <- dustify(c(0.31, 0.32))
sd_upper_test  <- dustify(0.31)

any(sd_rec_test_both < sd_upper_test)
```

Returns FALSE when it should return TRUE, as a trivial consequence of 0.31 - epsilon < 0.31 + epsilon. 
This occurs because of vector recycling in element-wise vector comparisons. Instead of performing 8 comparisons, between each element of the first vector and each element of the second vector, R instead performs only 4 comparisons., equivalent to. 

```
sd_rec_test_both[1] < sd_upper_test[1]    # 0.309999999999 < 0.309999999999    -> FALSE
sd_rec_test_both[2] < sd_upper_test[2]    # 0.310000000001 < 0.310000000001    -> FALSE
sd_rec_test_both[3] < sd_upper_test[1]    # 0.31999999999900003 < 0.309999999999 -> FALSE
sd_rec_test_both[4] < sd_upper_test[2]    # 0.320000000001 < 0.310000000001     -> FALSE
```

In such cases, it is possible to miss the true comparison purely because of the ordering of elements, and if this occurs in the critical path, it can result in a flipped bool in the final output. 

Replacing the comparison logic `any(vec1 cmp vec2)` with `any(outer(vec1, vec2, "cmp"))` is sufficient to eliminate this bug. 


**Consequence 2:** GRIM could produce an obtuse warning ("Warning: longer object length is not a multiple of shorter object length") and possibly return an incorrect response due to the following:

```
length_2ers <- c("up_or_down", "up_from_or_down_from", "ceiling_or_floor")
any(rounding == length_2ers)
```
For a vector `rounding` of length != 3, this warning may be returned to the user, failing to provide useful information, and GRIM may lead to unintended behavior under certain circumstances. 

For instance, the following code:

```
rounding = c("anti_trunc", "up_or_down")
length_2ers <- c("up_or_down", "up_from_or_down_from", "ceiling_or_floor")
any(rounding == length_2ers)
```

Returns FALSE, when the clear intention is that it should return TRUE. This is, once again, because of vector recycling and the order of the rounding elements. Switching the order, such that `rounding = c("up_or_down", "anti_trunc")`, now returns TRUE as intended. 

This may lead to incorrect behavior further down the chain as the wrong rounding behavior is applied. 

The user-end solution would be to alter the length and/or order of the rounding vector, but this is not adequately communicated to the user and is not reasonable to impose. 

We can instead eliminate this error by replacing `any(vec1 == vec2)` with `any(vec1 %in% vec2)`, using the more comprehensive `%in%` operator to ensure that we search for all possible comparisons. This is robust to differing vector lengths and ordering, and even to used of scalar-vector comparisons in either order.  

This second consequence is not as serious and likely has not been encountered by any user, since check_rounding_singular() limits the possible rounding inputs to grim_map(), and replicating this error requires an extremely contrived example, such as

```
pigs1 %>%
  grim_map(rounding = c("down", "up", "down", "up"), show_rec = TRUE)
```

Nevertheless, it is worth fixing, as the fix is simple and this could become a larger issue in the course of later refactoring. 

**Conclusion:** 

Any instance of possible element-wise vector comparison should be (please pardon the pun) scrutinized. The `%in%` operator should be preferred to the logical equality comparison `==` for comparing vector element equality, and the `outer()` function, as described in Consequence 1, should be preferred for comparing vector element inequality. 

Vector-recycling'ly yours,
NRP