### PR TITLE
Remove element with incorrect property

### DIFF
--- a/R/debit-plot.R
+++ b/R/debit-plot.R
@@ -220,8 +220,7 @@ debit_plot <- function(data,
     p <- p +
       ggplot2::theme_update() +
       ggplot2::theme(
-        panel.grid.minor = ggplot2::element_blank(),
-        axis.ticks.y = ggplot2::element_line(seq(0, 0.5, 0.1))
+        panel.grid.minor = ggplot2::element_blank()
       )
   }
 


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.

The issue in this case was that a theme element had invalid properties, see https://github.com/tidyverse/ggplot2/issues/6507.
I couldn't deduce the intent behind the code, so in this PR I removed the offending element altogether.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
