### PR TITLE
Fix for upcoming testthat 3.3.0 release

### DIFF
--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -10,7 +10,7 @@ expect_na <- function(object) {
   } else if (!is_na) {
     paste(act$lab, "must be `NA`.")
   } else {
-    NULL
+    ""
   }
 
   act$is_na <- is_na


### PR DESCRIPTION
`expect()` now checks its inputs and the fail message must always be a string.  But there are now better ways to write your own expectations AND I've actually documented them 😀 See details at https://testthat.r-lib.org/dev/articles/custom-expectation.html