### PR TITLE
conduct three GRIMMER tests with all possible sum(x) integers

### DIFF
--- a/R/grimmer.R
+++ b/R/grimmer.R
@@ -170,13 +170,11 @@ grimmer_scalar <- function(
   for (ii in seq_along(x_real_possible)) {
     x_real <- x_real_possible[ii]
     sum_real <- x_real * n_items
-    cat(x_real,"\n")
     
 
     # Sum of squares bounds, lower and upper:
     sum_squares_lower <- ((n - 1) * sd_lower^2 + n * x_real^2) * items^2
     sum_squares_upper <- ((n - 1) * sd_upper^2 + n * x_real^2) * items^2
-    cat(sum_squares_lower, sum_squares_upper, "\n")
 
     # TEST 1: Check that there is at least one integer between the lower and upper
     # bounds (of the reconstructed sum of squares of the -- most likely unknown --
@@ -255,7 +253,7 @@ grimmer_scalar <- function(
   }
   # convert test1_results, test2_results, test3_results to a dataframe of 3 rows (test1, test2, test3) and length(x_real_possible) columns
   test_results <- rbind(test1_results, test2_results, test3_results)
-  print(test_results)
+
   # if any of the columns has all TRUE values, then the inputs are GRIMMER-consistent
   pass3 <- apply(test_results, 2, function(x) all(x))
   if (any(pass3)) {


### PR DESCRIPTION
Currently, for SD, the script rounds up and down the reported SD to find the upper and lower bound of SD, then the upper and lower bounds of sum(x^2), and test each integer within the bounds. The same should be done with the mean: first, round up and down the reported mean to find the upper and lower bounds of the actual mean, then the upper and lower bounds of sum(x), and test each interger within the bounds. Then, for each possible integer sum(x), do the SD computation.

Per the example of mean = 3.1, n = 16, digits = 1
First we round 3.1 to [3.05, 3.15], multiply by 16 to get the bounds [48.8, 50.4], which captures the two candidate integers 49 and 50. Because some intergers are found for sum(x), it passes the GRIM test.

Then, for either 49 or 50, apply the three GRIMMER tests. If either 49 or 50 passes all three tests, the reported SD passes.
Otherwise, if either 49 or 50 passes the first two tests, we report failure due to test 3.
Otherwise, if either 49 or 50 passes the first test, we report failure due to test 2.
Otherwise, we report falure due to test 1 (where neither 49 or 50 passes even test 1).